### PR TITLE
Add stronger schema definition for map (structs) mutations

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,7 +9,8 @@ config :ex_dgraph, ExDgraph,
   # linearly increase the delay from 150ms following a Fibonacci pattern,
   # cap the delay at 15 seconds (the value defined by the default `:timeout`
   # parameter) and giving up after 3 attempts
-  retry_linear_backoff: [delay: 150, factor: 2, tries: 3]
+  retry_linear_backoff: [delay: 150, factor: 2, tries: 3],
+  enforce_struct_schema: false
 
 # the `retry_linear_backoff` values above are also the default driver values,
 # re-defined here mostly as a reminder

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,8 @@ config :ex_dgraph, ExDgraph,
   # linearly increase the delay from 150ms following a Fibonacci pattern,
   # cap the delay at 15 seconds (the value defined by the default `:timeout`
   # parameter) and giving up after 3 attempts
-  retry_linear_backoff: [delay: 150, factor: 2, tries: 3]
+  retry_linear_backoff: [delay: 150, factor: 2, tries: 3],
+  enforce_struct_schema: true
 
 # the `retry_linear_backoff` values above are also the default driver values,
 # re-defined here mostly as a reminder

--- a/lib/exdgraph.ex
+++ b/lib/exdgraph.ex
@@ -716,6 +716,59 @@ defmodule ExDgraph do
   @spec set_map!(conn, Map.t()) :: {:ok, ExDgraph.Response} | {:error, ExDgraph.Error}
   defdelegate set_map!(conn, map), to: Mutation
 
+  @doc """
+  This function allow you to convert an struct type into a mutation (json based) type in dgraph.
+  It also allows you to enforce the schema in database (adding a "class name" info before every predicate, this class name is the single name given to the elixir module struct) by activating the `enforce_struct_schema` in the config files.
+  The function sends the mutation to the server and returns `{:ok, result}` or `{:error, error}` otherwise.
+  Internally it uses Dgraphs `set_json`.
+  The `result` is a map without the "classname" (you can apply the built-in function `struct` to convert the map into the struct you desire) of all values you have passed in but with the field `uid` populated from the database.
+
+  ## Examples
+
+  ```elixir
+  struct_data = %MutationTest.Person{
+    name: "Alice",
+    identifier: "alice_json",
+    dogs: [
+      %MutationTest.Dog{
+        name: "Bello"
+      }
+    ]
+  }
+   ```
+
+      iex> ExDgraph.set_struct(conn, struct_data)
+      %{:ok,
+        %{
+          context: %ExDgraph.Api.TxnContext{
+            aborted: false,
+            commit_ts: 1703,
+            keys: [],
+            lin_read: %ExDgraph.Api.LinRead{ids: %{1 => 1508}},
+            start_ts: 1702
+          },
+          result: %{
+            dogs: [%{name: "Bello", uid: "0xd82"}],
+            name: "Alice",
+            uid: "0xd81"
+          },
+          uids: %{
+            "763d617a-af34-4ff9-9863-e072bf85146d" => "0xd82",
+            "e94713a5-54a7-4e36-8ab8-0d3019409892" => "0xd81"
+          }
+        }
+      }
+  """
+  @spec set_struct(conn, Map.t()) :: {:ok, ExDgraph.Response} | {:error, ExDgraph.Error}
+  defdelegate set_struct(conn, map), to: Mutation
+
+  @doc """
+  The same as `set_struct/2` but raises an `ExDgraph.Exception` if it fails.
+  Returns the server response otherwise.
+  """
+  @spec set_struct!(conn, Map.t()) :: {:ok, ExDgraph.Response} | {:error, ExDgraph.Error}
+  defdelegate set_struct!(conn, map), to: Mutation
+
   ## Operation
   ######################
 

--- a/lib/exdgraph.ex
+++ b/lib/exdgraph.ex
@@ -402,7 +402,7 @@ defmodule ExDgraph do
   @pool_name :ex_dgraph_pool
   @timeout 15_000
 
-  alias ExDgraph.Api.{Dgraph, Request, Response, Mutation, Operation}
+  alias ExDgraph.Api.{Mutation, Operation}
   alias ExDgraph.{ConfigAgent, Operation, Mutation, Query, Utils}
 
   @type conn :: DBConnection.conn()

--- a/lib/exdgraph/mutation.ex
+++ b/lib/exdgraph/mutation.ex
@@ -2,7 +2,7 @@ defmodule ExDgraph.Mutation do
   @moduledoc """
   Provides the functions for the callbacks from the DBConnection behaviour.
   """
-  alias ExDgraph.{Exception, MutationStatement, QueryStatement, Transform}
+  alias ExDgraph.{Exception, MutationStatement, Transform}
 
   @doc false
   def mutation!(conn, statement) do
@@ -48,6 +48,31 @@ defmodule ExDgraph.Mutation do
     end
   end
 
+  @doc false
+  def set_struct(conn, struct) do
+    struct_with_tmp_uids = tmp_ids_into_struct(struct)
+    json = Poison.encode!(struct_with_tmp_uids)
+
+    case set_struct_commit(conn, json, struct_with_tmp_uids) do
+      {:error, f} -> {:error, code: f.code, message: f.message}
+      r -> {:ok, r}
+    end
+  end
+
+  @doc false
+  def set_struct!(conn, struct) do
+    struct_with_tmp_uids = tmp_ids_into_struct(struct)
+    json = Poison.encode!(struct_with_tmp_uids)
+
+    case set_struct_commit(conn, json, struct_with_tmp_uids) do
+      {:error, f} ->
+        raise Exception, code: f.code, message: f.message
+
+      r ->
+        r
+    end
+  end
+
   defp mutation_commit(conn, statement) do
     exec = fn conn ->
       q = %MutationStatement{statement: statement}
@@ -82,28 +107,26 @@ defmodule ExDgraph.Mutation do
     DBConnection.run(conn, exec, run_opts())
   end
 
-  defp insert_tmp_uids(map) when is_list(map), do: Enum.map(map, &insert_tmp_uids/1)
+  defp set_struct_commit(conn, json, struct_with_tmp_uids) do
+    exec = fn conn ->
+      q = %MutationStatement{set_json: json}
 
-  defp insert_tmp_uids(map = %x{}) do
-    schema = x |> get_schema_name()
+      case DBConnection.execute(conn, q, %{}) do
+        {:ok, resp} ->
+          parsed_response = Transform.transform_mutation(resp)
+          # Now exchange the tmp ids for the ones returned from the db
+          result_with_uids = replace_tmp_struct_uids(struct_with_tmp_uids, parsed_response.uids)
+          Map.put(parsed_response, :result, result_with_uids)
 
-    map
-    |> Map.from_struct()
-    |> Map.update(:uid, "_:#{UUID.uuid4()}", fn
-      nil -> "_:#{UUID.uuid4()}"
-      existing_uuid -> existing_uuid
-    end)
-    |> Enum.reduce(
-      %{},
-      fn
-        {:uid, map_value}, a ->
-          Map.merge(a, %{:uid => insert_tmp_uids(map_value)})
-
-        {key, map_value}, a ->
-          Map.merge(a, %{"#{schema}.#{key}" => insert_tmp_uids(map_value)})
+        other ->
+          other
       end
-    )
+    end
+
+    DBConnection.run(conn, exec, run_opts())
   end
+
+  defp insert_tmp_uids(map) when is_list(map), do: Enum.map(map, &insert_tmp_uids/1)
 
   defp insert_tmp_uids(map) when is_map(map) do
     map
@@ -117,6 +140,46 @@ defmodule ExDgraph.Mutation do
   end
 
   defp insert_tmp_uids(value), do: value
+
+  defp tmp_ids_into_struct(map) when is_list(map), do: Enum.map(map, &tmp_ids_into_struct/1)
+
+  defp tmp_ids_into_struct(map = %x{}) do
+    schema = x |> get_schema_name()
+
+    map
+    |> Map.from_struct()
+    |> Map.update(:uid, "_:#{UUID.uuid4()}", fn
+      nil -> "_:#{UUID.uuid4()}"
+      existing_uuid -> existing_uuid
+    end)
+    |> Enum.reduce(
+      %{},
+      fn
+        {:uid, map_value}, a ->
+          Map.merge(a, %{:uid => tmp_ids_into_struct(map_value)})
+
+        {key, map_value}, a ->
+          if Application.get_env(:ex_dgraph, ExDgraph)[:enforce_struct_schema] do
+            Map.merge(a, %{"#{schema}.#{key}" => tmp_ids_into_struct(map_value)})
+          else
+            Map.merge(a, %{key => tmp_ids_into_struct(map_value)})
+          end
+      end
+    )
+  end
+
+  defp tmp_ids_into_struct(map) when is_map(map) do
+    map
+    |> Map.update(:uid, "_:#{UUID.uuid4()}", fn existing_uuid -> existing_uuid end)
+    |> Enum.reduce(
+      %{},
+      fn {key, map_value}, a ->
+        Map.merge(a, %{key => tmp_ids_into_struct(map_value)})
+      end
+    )
+  end
+
+  defp tmp_ids_into_struct(value), do: value
 
   defp replace_tmp_uids(map, uids) when is_list(map),
     do: Enum.map(map, &replace_tmp_uids(&1, uids))
@@ -132,8 +195,6 @@ defmodule ExDgraph.Mutation do
     |> Enum.reduce(
       %{},
       fn {key, map_value}, a ->
-        # delete the schema prefix
-        key = key |> to_string() |> String.split(".") |> List.last() |> String.to_existing_atom()
         Map.merge(a, %{key => replace_tmp_uids(map_value, uids)})
       end
     )
@@ -141,11 +202,31 @@ defmodule ExDgraph.Mutation do
 
   defp replace_tmp_uids(value, _uids), do: value
 
-  defp get_schema_name(schema) do
-    schema |> to_string() |> String.split(".") |> List.last() |> String.downcase()
+  defp replace_tmp_struct_uids(map, uids) when is_list(map),
+    do: Enum.map(map, &replace_tmp_struct_uids(&1, uids))
+
+  defp replace_tmp_struct_uids(map, uids) when is_map(map) do
+    map
+    |> Map.update(:uid, map[:uid], fn existing_uuid ->
+      case String.slice(existing_uuid, 0, 2) == "_:" do
+        true -> uids[String.replace_leading(existing_uuid, "_:", "")]
+        false -> existing_uuid
+      end
+    end)
+    |> Enum.reduce(
+      %{},
+      fn {key, map_value}, a ->
+        # delete the schema prefix
+        key = key |> to_string() |> String.split(".") |> List.last() |> String.to_existing_atom()
+        Map.merge(a, %{key => replace_tmp_struct_uids(map_value, uids)})
+      end
+    )
   end
 
-  defp get_real_uid(tmp_value, uids) do
+  defp replace_tmp_struct_uids(value, _uids), do: value
+
+  defp get_schema_name(schema) do
+    schema |> to_string() |> String.split(".") |> List.last() |> String.downcase()
   end
 
   defp run_opts do

--- a/lib/exdgraph/protocol.ex
+++ b/lib/exdgraph/protocol.ex
@@ -92,7 +92,7 @@ defmodule ExDgraph.Protocol do
     {:ok, state}
   end
 
-  defp execute(%QueryStatement{statement: statement}, params, _, channel) do
+  defp execute(%QueryStatement{statement: statement}, _params, _, channel) do
     request = ExDgraph.Api.Request.new(query: statement)
 
     case ExDgraph.Api.Dgraph.Stub.query(channel, request) do
@@ -107,18 +107,19 @@ defmodule ExDgraph.Protocol do
       {:error, e, channel}
   end
 
-  defp execute(%MutationStatement{statement: statement, set_json: set_json}, params, _, channel) do
+  defp execute(%MutationStatement{statement: statement, set_json: set_json}, _params, _, channel) do
     # Build request
-    cond do
-      statement != "" and set_json == "" ->
-        request = ExDgraph.Api.Mutation.new(set_nquads: statement, commit_now: true)
+    request =
+      cond do
+        statement != "" and set_json == "" ->
+          ExDgraph.Api.Mutation.new(set_nquads: statement, commit_now: true)
 
-      set_json != "" and set_json != "" ->
-        request = ExDgraph.Api.Mutation.new(set_json: set_json, commit_now: true)
+        set_json != "" and set_json != "" ->
+          ExDgraph.Api.Mutation.new(set_json: set_json, commit_now: true)
 
-      statement != "" and set_json != "" ->
-        raise Exception, code: 2, message: "Both set_json and statement defined"
-    end
+        statement != "" and set_json != "" ->
+          raise Exception, code: 2, message: "Both set_json and statement defined"
+      end
 
     case ExDgraph.Api.Dgraph.Stub.mutate(channel, request) do
       {:ok, res} ->
@@ -134,7 +135,7 @@ defmodule ExDgraph.Protocol do
 
   defp execute(
          %OperationStatement{drop_all: drop_all, schema: schema, drop_attr: drop_attr},
-         params,
+         _params,
          _,
          channel
        ) do

--- a/lib/exdgraph/utils.ex
+++ b/lib/exdgraph/utils.ex
@@ -5,36 +5,36 @@ defmodule ExDgraph.Utils do
 
   def as_rendered(value) do
     case value do
-      x when is_list(x) -> x |> Poison.encode!
-      %Date{} = x       -> x |> Date.to_iso8601 |> Kernel.<>("T00:00:00.0+00:00")
-      %DateTime{} = x   -> x |> DateTime.to_iso8601 |> String.replace("Z", "+00:00")
-      x                 -> x |> to_string
+      x when is_list(x) -> x |> Poison.encode!()
+      %Date{} = x -> x |> Date.to_iso8601() |> Kernel.<>("T00:00:00.0+00:00")
+      %DateTime{} = x -> x |> DateTime.to_iso8601() |> String.replace("Z", "+00:00")
+      x -> x |> to_string
     end
   end
 
   def infer_type(type) do
     case type do
-      x when is_boolean(x)  -> :bool
-      x when is_binary(x)   -> :string
-      x when is_integer(x)  -> :int
-      x when is_float(x)    -> :float
-      x when is_list(x)     -> :geo
-      %DateTime{}           -> :datetime
-      %Date{}               -> :date
-      %Uid{}                -> :uid
+      x when is_boolean(x) -> :bool
+      x when is_binary(x) -> :string
+      x when is_integer(x) -> :int
+      x when is_float(x) -> :float
+      x when is_list(x) -> :geo
+      %DateTime{} -> :datetime
+      %Date{} -> :date
+      %Uid{} -> :uid
     end
   end
 
   def as_literal(value, type) do
     case {type, value} do
-      {:int, v} when is_integer(v)      -> {:ok, to_string(v)}
-      {:float, v} when is_float(v)      -> {:ok, as_rendered(v)}
-      {:bool, v} when is_boolean(v)     -> {:ok, as_rendered(v)}
-      {:string, v} when is_binary(v)    -> {:ok, v |> strip_quotes |> wrap_quotes}
-      {:date, %Date{} = v}              -> {:ok, as_rendered(v)}
-      {:datetime, %DateTime{} = v}      -> {:ok, as_rendered(v)}
-      {:geo, v} when is_list(v)         -> check_and_render_geo_numbers(v)
-      {:uid, v} when is_binary(v)       -> {:ok, "<"<>v<>">"}
+      {:int, v} when is_integer(v) -> {:ok, to_string(v)}
+      {:float, v} when is_float(v) -> {:ok, as_rendered(v)}
+      {:bool, v} when is_boolean(v) -> {:ok, as_rendered(v)}
+      {:string, v} when is_binary(v) -> {:ok, v |> strip_quotes |> wrap_quotes}
+      {:date, %Date{} = v} -> {:ok, as_rendered(v)}
+      {:datetime, %DateTime{} = v} -> {:ok, as_rendered(v)}
+      {:geo, v} when is_list(v) -> check_and_render_geo_numbers(v)
+      {:uid, v} when is_binary(v) -> {:ok, "<" <> v <> ">"}
       _ -> {:error, {:invalidly_typed_value, value, type}}
     end
   end
@@ -47,7 +47,7 @@ defmodule ExDgraph.Utils do
   end
 
   defp check_and_render_geo_numbers(nums) do
-    if nums |> List.flatten |> Enum.all?(&is_float/1) do
+    if nums |> List.flatten() |> Enum.all?(&is_float/1) do
       {:ok, nums |> as_rendered}
     else
       {:error, :invalid_geo_json}
@@ -64,7 +64,6 @@ defmodule ExDgraph.Utils do
     |> String.replace(~r/"&/, "")
   end
 
-
   def has_function?(module, func, arity) do
     :erlang.function_exported(module, func, arity)
   end
@@ -76,8 +75,9 @@ defmodule ExDgraph.Utils do
 
   def get_value(params, key, default \\ nil) when is_atom(key) do
     str_key = to_string(key)
+
     cond do
-      Map.has_key?(params, key)     -> Map.get(params, key)
+      Map.has_key?(params, key) -> Map.get(params, key)
       Map.has_key?(params, str_key) -> Map.get(params, str_key)
       true -> default
     end
@@ -101,6 +101,7 @@ defmodule ExDgraph.Utils do
     |> Keyword.put_new(:keyfile, nil)
     |> Keyword.put_new(:cacertfile, nil)
     |> Keyword.put_new(:retry_linear_backoff, delay: 150, factor: 2, tries: 3)
+    |> Keyword.put_new(:enforce_struct_schema, false)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end
 end

--- a/test/mutation_test.exs
+++ b/test/mutation_test.exs
@@ -1,5 +1,9 @@
 defmodule MutationTest.Person do
-  defstruct [:uid, :name, :identifier, :friends]
+  defstruct [:uid, :name, :identifier, :dogs]
+end
+
+defmodule MutationTest.Dog do
+  defstruct [:uid, :name]
 end
 
 defmodule MutationTest do
@@ -12,8 +16,8 @@ defmodule MutationTest do
   @struct_insert_mutation %MutationTest.Person{
     name: "Alice",
     identifier: "alice_json",
-    friends: [
-      %MutationTest.Person{
+    dogs: [
+      %MutationTest.Dog{
         name: "Betty"
       }
     ]
@@ -25,9 +29,9 @@ defmodule MutationTest do
         {
           uid
           name : person.name
-          friends : person.friends
+          dogs : person.dogs
           {
-            name : person.name
+            name : dog.name
             uid
           }
         }
@@ -139,7 +143,7 @@ defmodule MutationTest do
 
   # TODO: Take care of updates via uid
   test "set_map/2 struct returns {:ok, mutation_msg} for correct mutation", %{conn: conn} do
-    {status, mutation_msg} = ExDgraph.set_map(conn, @struct_insert_mutation)
+    {status, mutation_msg} = ExDgraph.set_struct(conn, @struct_insert_mutation)
     assert status == :ok
     assert mutation_msg.context.aborted == false
     query_msg = ExDgraph.Query.query!(conn, @struct_insert_check_query)
@@ -147,45 +151,45 @@ defmodule MutationTest do
     people = res[:people]
     alice = List.first(people)
     assert alice[:name] == "Alice"
-    betty = List.first(alice[:friends])
+    betty = List.first(alice[:dogs])
     assert betty[:name] == "Betty"
   end
 
   test "set_map!/2 struct returns mutation_message", %{conn: conn} do
-    mutation_msg = ExDgraph.set_map!(conn, @struct_insert_mutation)
+    mutation_msg = ExDgraph.set_struct!(conn, @struct_insert_mutation)
     assert mutation_msg.context.aborted == false
     query_msg = ExDgraph.Query.query!(conn, @struct_insert_check_query)
     res = query_msg.result
     people = res[:people]
     alice = List.first(people)
     assert alice[:name] == "Alice"
-    betty = List.first(alice[:friends])
+    betty = List.first(alice[:dogs])
     assert betty[:name] == "Betty"
   end
 
   test "set_map/2 struct returns result with uids", %{conn: conn} do
-    {status, mutation_msg} = ExDgraph.set_map(conn, @struct_insert_mutation)
+    {status, mutation_msg} = ExDgraph.set_struct(conn, @struct_insert_mutation)
     assert status == :ok
     assert is_map(mutation_msg.result)
     mutation_alice = mutation_msg.result
-    mutation_betty = List.first(mutation_alice[:friends])
+    mutation_betty = List.first(mutation_alice[:dogs])
     query_msg = ExDgraph.Query.query!(conn, @struct_insert_check_query)
     query_people = query_msg.result[:people]
     query_alice = List.first(query_people)
-    query_betty = List.first(query_alice[:friends])
+    query_betty = List.first(query_alice[:dogs])
     assert mutation_alice[:uid] == query_alice[:uid]
     assert mutation_betty[:uid] == query_betty[:uid]
   end
 
   test "set_map!/2 struct returns result with uids", %{conn: conn} do
-    mutation_msg = ExDgraph.set_map!(conn, @struct_insert_mutation)
+    mutation_msg = ExDgraph.set_struct!(conn, @struct_insert_mutation)
     assert is_map(mutation_msg.result)
     mutation_alice = mutation_msg.result
-    mutation_betty = List.first(mutation_alice[:friends])
+    mutation_betty = List.first(mutation_alice[:dogs])
     query_msg = ExDgraph.Query.query!(conn, @struct_insert_check_query)
     query_people = query_msg.result[:people]
     query_alice = List.first(query_people)
-    query_betty = List.first(query_alice[:friends])
+    query_betty = List.first(query_alice[:dogs])
     assert mutation_alice[:uid] == query_alice[:uid]
     assert mutation_betty[:uid] == query_betty[:uid]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,7 +7,13 @@ defmodule ExDgraph.TestHelper do
       age: int @index(int) .
       friend: uid @count .
       dob: dateTime .
-      identifier: string @index(exact, term) ."
+      identifier: string @index(exact, term) .
+      person.id: string @index(exact).
+      person.name: string @index(exact, term) @count .
+      person.age: int @index(int) .
+      person.friend: uid @count .
+      person.dob: dateTime .
+      person.identifier: string @index(exact, term) ."
 
   @starwars_creation_mutation """
      _:luke <name> "Luke Skywalker" .

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,10 +8,13 @@ defmodule ExDgraph.TestHelper do
       friend: uid @count .
       dob: dateTime .
       identifier: string @index(exact, term) .
+      some: string @index(exact, term) .
+      map_owner: uid .
       person.id: string @index(exact).
       person.name: string @index(exact, term) @count .
       person.age: int @index(int) .
       person.dogs: uid @count .
+      person.some_map: uid .
       person.dob: dateTime .
       person.identifier: string @index(exact, term) .
       dog.name: string @index(exact, term) @count ."

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,9 +11,10 @@ defmodule ExDgraph.TestHelper do
       person.id: string @index(exact).
       person.name: string @index(exact, term) @count .
       person.age: int @index(int) .
-      person.friend: uid @count .
+      person.dogs: uid @count .
       person.dob: dateTime .
-      person.identifier: string @index(exact, term) ."
+      person.identifier: string @index(exact, term) .
+      dog.name: string @index(exact, term) @count ."
 
   @starwars_creation_mutation """
      _:luke <name> "Luke Skywalker" .


### PR DESCRIPTION
Hello o/ 

I've been working with dgraph for a while in a personal project, one of the problems of dgraph is that don't have an strong schema definition, the use of indexes without a "proper" schema is a big problem, here an example of what I mean:

Let's suppose we have a database with movies and their characters, so you define the name edge

`name: string @index(term) .`

And you add the `movie` with the name `Thor`, but you also add the `character` with the name `Thor` (which is valid in this context), the two have the same name definition, they could have different edges as well, but if you you do a term search for the name `Thor` you'll get both the `movie` and the `character`, I (and others as well) discussed it with the dev team, for the moment the best solution is creating indexes like this:

`movie.name: string @index(term) .`
`character.name: string @index(term) .`

This allow you to be more explicit on exactly what you want to query and don't have mixed data

So this PR take the user defined structs, check if it is an struct and add the name of that struct (for example `MyApp.Models.Player` and turn it into a "schema" for dgrapg (like this `player.(the struct name definition)`, I also fixed a few problems in code that dializer warned

### Summary of the PR

- Add a stronger schema for mutations making use of Structs
- Fixing unsafe variables
- Fixing non-used variables

Greetings ^^/