### PR TITLE
fix(protocol): handle :gun_up and :gun_down as debug level for now

### DIFF
--- a/lib/exdgraph/protocol.ex
+++ b/lib/exdgraph/protocol.ex
@@ -87,7 +87,7 @@ defmodule ExDgraph.Protocol do
     end
   end
 
-  def handle_info({:gun_up, _pid, _protocol}) do
+  def handle_info({:gun_up, _pid, _protocol}, state) do
     Logger.debug(fn ->
       [inspect(__MODULE__), ?\s, inspect(self()), " received gun_up from server"]
     end)
@@ -95,7 +95,7 @@ defmodule ExDgraph.Protocol do
      {:ok, state}
   end
 
-  def handle_info({:gun_down, _pid, _protocol, _level, _, _}) do
+  def handle_info({:gun_down, _pid, _protocol, _level, _, _}, state) do
     Logger.debug(fn ->
       [inspect(__MODULE__), ?\s, inspect(self()), " received gun_down from server"]
     end)

--- a/lib/exdgraph/protocol.ex
+++ b/lib/exdgraph/protocol.ex
@@ -87,6 +87,22 @@ defmodule ExDgraph.Protocol do
     end
   end
 
+  def handle_info({:gun_up, _pid, _protocol}) do
+    Logger.debug(fn ->
+      [inspect(__MODULE__), ?\s, inspect(self()), " received gun_up from server"]
+    end)
+
+     {:ok, state}
+  end
+
+  def handle_info({:gun_down, _pid, _protocol, _level, _, _}) do
+    Logger.debug(fn ->
+      [inspect(__MODULE__), ?\s, inspect(self()), " received gun_down from server"]
+    end)
+
+    {:ok, state}
+  end
+
   def handle_info(msg, state) do
     Logger.error(fn ->
       [inspect(__MODULE__), ?\s, inspect(self()), " received unexpected message: " | inspect(msg)]


### PR DESCRIPTION
I am still receiving "unexpected message received" warnings even after the :gun fix so I am proposing we catch those two messages and log them as a debug level issue until we can figure out the issue.