### PR TITLE
Set the GRPC deadline and DBConnection checkout timeout to use :timeout

### DIFF
--- a/lib/exdgraph.ex
+++ b/lib/exdgraph.ex
@@ -53,7 +53,7 @@ defmodule ExDgraph do
     port: 9080,
     pool_size: 5,
     max_overflow: 1
-    timeout: 15_000,
+    timeout: 15_000, # This value is used for the DBConnection timeout and the GRPC client deadline
     pool: DBConnection.Poolboy,
     ssl: false,
     tls_client_auth: false,

--- a/lib/exdgraph/protocol.ex
+++ b/lib/exdgraph/protocol.ex
@@ -48,6 +48,7 @@ defmodule ExDgraph.Protocol do
 
   @doc "Callback for DBConnection.disconnect/1"
   def disconnect(_err, _state) do
+    :ok
   end
 
   @doc "Callback for DBConnection.handle_begin/1"
@@ -117,8 +118,8 @@ defmodule ExDgraph.Protocol do
 
   defp execute(%QueryStatement{statement: statement}, _params, _, channel) do
     request = ExDgraph.Api.Request.new(query: statement)
-
-    case ExDgraph.Api.Dgraph.Stub.query(channel, request) do
+    timeout = ExDgraph.config(:timeout)
+    case ExDgraph.Api.Dgraph.Stub.query(channel, request, timeout: timeout) do
       {:ok, res} ->
         {:ok, res, channel}
 
@@ -159,8 +160,8 @@ defmodule ExDgraph.Protocol do
          channel
        ) do
     operation = Api.Operation.new(drop_all: drop_all, schema: schema, drop_attr: drop_attr)
-
-    case ExDgraph.Api.Dgraph.Stub.alter(channel, operation) do
+    timeout = ExDgraph.config(:timeout)
+    case ExDgraph.Api.Dgraph.Stub.alter(channel, operation, timeout: timeout) do
       {:ok, res} ->
         {:ok, res, channel}
 
@@ -173,7 +174,8 @@ defmodule ExDgraph.Protocol do
   end
 
   defp do_mutate(channel, request) do
-    case ExDgraph.Api.Dgraph.Stub.mutate(channel, request) do
+    timeout = ExDgraph.config(:timeout)
+    case ExDgraph.Api.Dgraph.Stub.mutate(channel, request, timeout: timeout) do
       {:ok, res} ->
         {:ok, res, channel}
 

--- a/lib/exdgraph/query.ex
+++ b/lib/exdgraph/query.ex
@@ -7,7 +7,7 @@ defmodule ExDgraph.Query do
   @doc false
   def query(conn, statement) do
     case query_commit(conn, statement) do
-      {:error, f} -> {:error, code: f.code, message: f.message}
+      {:error, f} -> {:error, code: Map.get(f, :code, Map.get(f, :status)), message: f.message}
       r -> {:ok, r}
     end
   end
@@ -32,12 +32,10 @@ defmodule ExDgraph.Query do
         other -> other
       end
     end
-
-    # Response.transform(DBConnection.run(conn, exec, run_opts()))
     DBConnection.run(conn, exec, run_opts())
   end
 
   defp run_opts do
-    [pool: ExDgraph.config(:pool)]
+    [pool: ExDgraph.config(:pool), timeout: ExDgraph.config(:timeout)]
   end
 end


### PR DESCRIPTION
@ospaarmann knows about this. We were not setting the GRPC deadline so a query that took too long past the 15 second DBConnection timeout would continue to run on Dgraph. Separately, DBConnection checkout was never being set so the connection would always close after 15 seconds but would retry the query up until the `:timeout` value set. This PR fixes both of those issues.